### PR TITLE
Fix wrong parameter order

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -136,8 +136,8 @@ app.MapPost(
         try
         {
             var response = await aiService.GenerateCompletionAsync(
-                request.Model,
                 request.Prompt,
+                request.Model,
                 request.Temperature);
             return Results.Ok(response);
         }


### PR DESCRIPTION
## Summary
- fix parameter order when calling GenerateCompletionAsync

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624d1a664883289fe5c3e109b7247a